### PR TITLE
Fix `parse(::Type, ::Colorant)` warnings

### DIFF
--- a/ext/makie_recipes/RefMeshes_recipes.jl
+++ b/ext/makie_recipes/RefMeshes_recipes.jl
@@ -4,6 +4,9 @@ function Makie.plot!(plot::PlantViz{<:Tuple{Union{T,Vector{T}}}}) where {T<:RefM
     plot_refmesh(plot, :mtg)
 end
 
+_as_colorant(color::Colorant) = color
+_as_colorant(color) = parse(Colorant, color)
+
 function plot_refmesh(plot, mtg_name=:mtg)
     Makie.map!(plot.attributes, [:colormap], :colormap_resolved) do cm
         get_colormap(cm)
@@ -31,8 +34,10 @@ function plot_refmesh(plot, mtg_name=:mtg)
             colorant = c
         end
 
-        # Parsing the colors in the dictionary into Colorants:
-        colorant_dict = Dict{String,Union{Colorant,Vector{<:Colorant}}}([k => isa(v, AbstractArray) ? parse.(Colorant, v) : fill(parse(Colorant, v), PlantGeom.nvertices(p[k])) for (k, v) in colorant])
+        # Normalize user colors; avoid parsing values that are already Colorants.
+        colorant_dict = Dict([k => isa(v, AbstractArray) ?
+                                   _as_colorant.(v) :
+                                   fill(_as_colorant(v), PlantGeom.nvertices(p[k])) for (k, v) in colorant])
 
         if length(colorant) != n_meshes
             ref_cols = get_ref_meshes_color(opf)

--- a/src/colors/get_mtg_color.jl
+++ b/src/colors/get_mtg_color.jl
@@ -16,6 +16,9 @@ struct VectorColorant
     colors::Vector{Colorant}
 end
 
+_as_colorant(color::Colorant) = color
+_as_colorant(color) = parse(Colorant, color)
+
 """
     get_mtg_color(color, opf)
 
@@ -64,7 +67,7 @@ function get_mtg_color(::Type{AttributeColorantType}, color, opf)
 end
 
 function get_mtg_color(::Type{T}, color, opf) where {T<:Symbol}
-    return parse(Colorant, color)
+    return _as_colorant(color)
 end
 
 function get_mtg_color(::Type{T}, color, opf) where {T<:Colorant}
@@ -73,7 +76,7 @@ end
 
 function get_mtg_color(::Type{DictRefMeshColorantType}, color, opf)
     # Parsing the colors in the dictionary into Colorants:
-    new_color = Dict{String,Colorant}([k => parse(Colorant, v) for (k, v) in color])
+    new_color = Dict{String,Colorant}([k => _as_colorant(v) for (k, v) in color])
     return DictRefMeshColorant(new_color)
 end
 
@@ -86,10 +89,9 @@ function get_mtg_color(::Type{DictVertexRefMeshColorantType}, color, opf)
         n_verts = nvertices(ref_mesh)
         if v isa AbstractVector
             @assert length(v) == n_verts "The length of the color vector for refmesh $k does not match the number of vertices of that refmesh ($(length(v)) != $n_verts)"
-            col = v isa AbstractVector{Colorant} ? v : parse.(Colorant, v)
+            col = _as_colorant.(v)
         else
-            col = v isa Colorant ? v : parse(Colorant, v)
-            col = fill(col, n_verts)
+            col = fill(_as_colorant(v), n_verts)
         end
         push!(new_color, k => col)
     end
@@ -101,5 +103,5 @@ function get_mtg_color(::Type{VectorColorantType}, color, opf)
 end
 
 function get_mtg_color(::Type{VectorSymbolType}, color, opf)
-    return VectorColorant(parse.(Colorant, color))
+    return VectorColorant(_as_colorant.(color))
 end


### PR DESCRIPTION
We get this warning for some time:

```
┌ Warning: parse(::Type, ::Colorant) is deprecated.
│   Do not call parse if the object does not need to be parsed.
│   caller = (::PlantGeomMakie.var"#plot_refmesh##6#plot_refmesh##7"{Dict{String, Any}})(::Pair{String, RGBA{Float64}}) at none:?
└ @ Core ./none:-1
┌ Warning: parse(::Type, ::Colorant) is deprecated.
│   Do not call parse if the object does not need to be parsed.
│   caller = _broadcast_getindex_evalf at broadcast.jl:699 [inlined]
└ @ Core ./broadcast.jl:699
┌ Warning: parse(::Type, ::Colorant) is deprecated.
│   Do not call parse if the object does not need to be parsed.
│   caller = _broadcast_getindex_evalf at broadcast.jl:699 [inlined]
```

This PR fixes it